### PR TITLE
Cleanup and refactor Fall 2023

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -5,17 +5,6 @@ https://github.com/AidanNelson/SimpleMediasoupPeer/
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-these are the tracks we would like to produce
-used for re-initializing when client experiences
-a change in socket ID
-
-this.tracksToProduce = {
-    camera: {
-      track,
-      broadcast: false
-    }
-}
-
 // these are the tracks we are currently producing
 // keyed with their label
 this.producers = {
@@ -88,8 +77,6 @@ export class SimpleMediasoupPeer {
 
     this.sendTransport = null;
     this.recvTransport = null;
-
-    // this.tracksToProduce = {};
 
     this.latestAvailableProducers = {};
     this.desiredPeerConnections = new Set();
@@ -179,13 +166,6 @@ export class SimpleMediasoupPeer {
     await this.createRecvTransport();
 
     await this.addDataProducer();
-
-    // for (const label in this.tracksToProduce) {
-    //   const track = this.tracksToProduce[label].track;
-    //   const broadcast = this.tracksToProduce[label].broadcast;
-    //   const customEncodings = this.tracksToProduce[label].customEncodings;
-    //   this.addProducer(track, label, broadcast, customEncodings);
-    // }
   }
 
   async _addTrack({ track = null, customEncodings = null, appData = null }) {
@@ -312,7 +292,6 @@ export class SimpleMediasoupPeer {
       for (const producerId in this.latestAvailableProducers[peerId].producers) {
         const shouldConsume =
           this.desiredPeerConnections.has(peerId) ||
-          this.latestAvailableProducers[peerId].producers[producerId].broadcast ||
           this.options.autoConnect;
 
         if (shouldConsume) {
@@ -326,7 +305,6 @@ export class SimpleMediasoupPeer {
       for (const dataProducerId in this.latestAvailableProducers[peerId].dataProducers) {
         const shouldConsume =
           this.desiredPeerConnections.has(peerId) ||
-          this.latestAvailableProducers[peerId].dataProducers[dataProducerId].broadcast ||
           this.options.autoConnect;
 
         if (shouldConsume) {
@@ -678,8 +656,7 @@ export class SimpleMediasoupPeer {
     for (const producerId in consumers) {
       const consumer = consumers[producerId];
 
-      // by default do not let us pause a broadcasts
-      if (!consumer || consumer.appData.broadcast) continue;
+      if (!consumer) continue;
       if (!consumer.paused) {
         logger("Pausing consumer!");
 

--- a/examples/multiple-rooms/public/index.js
+++ b/examples/multiple-rooms/public/index.js
@@ -112,16 +112,18 @@ async function sendCamera() {
     await startCamera();
   }
 
-  const videoTrack = localStream.getVideoTracks()[0];
-  const audioTrack = localStream.getAudioTracks()[0];
+  mediasoupPeer.addStream(localStream);
 
-  if (videoTrack) {
-    mediasoupPeer.addTrack(videoTrack, "video");
-  }
+  // const videoTrack = localStream.getVideoTracks()[0];
+  // const audioTrack = localStream.getAudioTracks()[0];
 
-  if (audioTrack) {
-    mediasoupPeer.addTrack(audioTrack, "audio");
-  }
+  // if (videoTrack) {
+  //   mediasoupPeer.addTrack(videoTrack, "video");
+  // }
+
+  // if (audioTrack) {
+  //   mediasoupPeer.addTrack(audioTrack, "audio");
+  // }
 }
 
 async function startCamera() {

--- a/server/index.js
+++ b/server/index.js
@@ -138,7 +138,7 @@ class SimpleMediasoupPeerServer {
     {
         peerId1: {},
         peerId2: {
-            'producerId12345': {label: 'camera', peerId: '12jb12kja3', broadcast: true}
+            'producerId12345': {label: 'camera', peerId: '12jb12kja3'}
             'producerId88888': {label: 'microphone', peerId: '12jb12kja3'}
         }
     }
@@ -763,10 +763,6 @@ class SimpleMediasoupPeerServer {
     this.peers[producingPeerId].producers[producer.id][this.peers[producingPeerId].routerIndex] =
       producer;
 
-    if (appData.broadcast) {
-      this.broadcastProducer(producingPeerId, producer.id);
-    }
-
     return producer;
   }
 
@@ -800,37 +796,6 @@ class SimpleMediasoupPeerServer {
     // }
 
     return dataProducer;
-  }
-
-  async broadcastProducer(producingPeerId, producerId) {
-    // automatically create consumers for every other peer to consume this producer
-
-    for (const consumingPeerId in this.peers) {
-      if (consumingPeerId !== producingPeerId) {
-        const consumer = await this.getOrCreateConsumerForPeer(
-          consumingPeerId,
-          producingPeerId,
-          producerId
-        );
-        if (consumer) {
-          const consumerInfo = {
-            peerId: producingPeerId,
-            producerId: consumer.producerId,
-            id: consumer.id,
-            kind: consumer.kind,
-            rtpParameters: consumer.rtpParameters,
-            type: consumer.type,
-            appData: consumer.appData,
-            producerPaused: consumer.producerPaused,
-          };
-
-          this.peers[consumingPeerId].socket.emit("mediasoupSignaling", {
-            type: "createConsumer",
-            data: consumerInfo,
-          });
-        }
-      }
-    }
   }
 
   async createTransportForPeer(id, data) {

--- a/server/index.js
+++ b/server/index.js
@@ -360,12 +360,10 @@ class SimpleMediasoupPeerServer {
             producerPaused: consumer.producerPaused,
           };
 
-          this.peers[id].socket.emit("mediasoupSignaling", {
-            type: "createConsumer",
-            data: consumerInfo,
-          });
+          callback({data: consumerInfo});
         }
-        callback();
+
+        
         break;
       }
 
@@ -388,12 +386,8 @@ class SimpleMediasoupPeerServer {
             appData: dataConsumer.appData,
           };
 
-          this.peers[id].socket.emit("mediasoupSignaling", {
-            type: "createDataConsumer",
-            data: dataConsumerInfo,
-          });
+          callback({data: dataConsumerInfo});
         }
-        callback();
         break;
       }
 


### PR DESCRIPTION
Client:
* Removes `this.tracksToProduce` and auto-restarting tracks
* Add `addStream` and `removeStream` methods
* Removes `broadcast` parameter for new tracks (this can be done using customData)
* Add customData which is passed along with tracks (rather than prescribing a label)

To Do:
- [ ] - recombine tracks into streams on client-side?
- [ ] - keep room clients updated as new tracks are added rather than updating on a given frequency
